### PR TITLE
ci(github-actions): 👷 add conventional commit workflow

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,22 @@
+name: Conventional Commit Validation
+
+on:
+  push:
+    branches:
+      - "feature/**"
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+jobs:
+  build:
+    name: Conventional Commit Validation
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webiny/action-conventional-commits@v1.3.0
+        with:
+          allowed-commit-types: "feat,fix,docs,style,refactor,perf,test,build,ci,chore,revert,wip"


### PR DESCRIPTION
This PR adds a workflow for checking that PRs targeting protected branches and pushed commits on `feature/**` branches conform to the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard.