### PR TITLE
ci(formatting): 👷 add workflow file to enforce formatting of Markdown…

### DIFF
--- a/.github/workflows/enforce-formatting.yaml
+++ b/.github/workflows/enforce-formatting.yaml
@@ -1,0 +1,31 @@
+name: Enforce Formatting
+
+on:
+  push:
+    branches:
+      - "feature/**"
+    paths:
+      - ".github/workflows/enforce-formatting.yaml"
+      - "**.md"
+      - "**.toml"
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+    paths:
+      - ".github/workflows/enforce-formatting.yaml"
+      - "**.md"
+      - "**.toml"
+
+jobs:
+  build:
+    name: Checking For Formatting Violations
+    runs-on: self-hosted
+    steps:
+      - name: Cancel Workflow Action
+        uses: styfle/cancel-workflow-action@0.12.1
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - run: dprint check --config .dprint.json ./ --allow-no-files


### PR DESCRIPTION
… and Toml files