### PR TITLE
chore(github-actions): 🔧 drop actions/upload-artifact to v3 since v4 …

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -73,7 +73,7 @@ jobs:
         with:
           enablement: true
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "./dist"
       - name: Deploy to GitHub Pages 🚀


### PR DESCRIPTION
…doesn't exist